### PR TITLE
Added application/sla as MimeType supported by stl_thumb

### DIFF
--- a/stl.thumbnailer
+++ b/stl.thumbnailer
@@ -1,6 +1,6 @@
 [Thumbnailer Entry]
 Exec=/usr/local/bin/stl_thumb.py %i %o %s
-MimeType=application/stl;model/x.stl-binary;model/x.stl-ascii
+MimeType=application/sla;application/stl;model/x.stl-binary;model/x.stl-ascii
 
 
 


### PR DESCRIPTION
Previous to this, the `stl.xml` file describes *.stl files as of type `application/sla`.  This is consistent with some other software choices, so that's fine.

However, it only registers hooks for `application/stl`, so the thumbnailer never triggers.

This PR adds `application/sla` to the list of MIME types handled by the stl thumbnailer, so that it actually works on `*.stl` files.