### PR TITLE
Update to python 3

### DIFF
--- a/stl_thumb.py
+++ b/stl_thumb.py
@@ -12,7 +12,7 @@ size = ""
 def main():
 
     m = hashlib.md5()
-    m.update(fin)
+    m.update(fin.encode('utf8'))
 
     ff = "/tmp/stl_to_png_%s.scad" % m.hexdigest()
 

--- a/stl_thumb.py
+++ b/stl_thumb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import os
 import sys
@@ -34,7 +34,7 @@ if __name__ == '__main__':
     f.close()
 
     if len(sys.argv) != 4:
-        print "add args [in file] [out file] [size]"
+        print ("add args [in file] [out file] [size]")
         sys.exit(0)
     else:
         fin = sys.argv[1]


### PR DESCRIPTION
I installed this thumbnailer and it didn't work (#5). So I ran the python script by itself and found out it wasn't working because it still uses old python 2 syntax (#9). Also, the MD5 hash wasn't working because it only accepts bytes as an input. I have made it so it encodes the string to UTF-8.

I have tested this on Ubuntu 22.04 with Nautilus and now it works well.

![benchy_thumbnail](https://user-images.githubusercontent.com/41409702/180955870-638146da-f08d-49d2-b5cc-798b7a7b4739.png)


