### PR TITLE
Use stl-thumb as a dependency instead of openscad

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Shows thumbnails of STL files in Nautilus file browser. The sources are based on
 
 ## Install
 
-### Install OpenSCAD
+### Install stl-thumb
 
-This project use [OpenSCAD](http://www.openscad.org/) for thumbnails preview. You must install OpenSCAD before using it.
+This project use [stl-thumb](https://github.com/unlimitedbacon/stl-thumb) for thumbnails preview. You must install stl-thumb before using it.
 
 ### Install stl-thumbnailer
 

--- a/stl_thumb.py
+++ b/stl_thumb.py
@@ -9,7 +9,7 @@ fin = ""
 fout = ""
 
 def main():
-    cmd = "stl-thumb '%s' '%s.png' 2> /dev/null; mv '%s.png' '%s'" % (fin, fout, fout, fout)
+    cmd = "stl-thumb '%s' '%s.png' -s %s 2> /dev/null; mv '%s.png' '%s'" % (fin, fout, size, fout, fout)
     os.system(cmd)
 
     sys.exit(0)

--- a/stl_thumb.py
+++ b/stl_thumb.py
@@ -21,7 +21,7 @@ if __name__ == '__main__':
     f.close()
 
     if len(sys.argv) != 4:
-        print ("add args [in file] [out file]")
+        print ("add args [in file] [out file] [size]")
         sys.exit(0)
     else:
         fin = sys.argv[1]

--- a/stl_thumb.py
+++ b/stl_thumb.py
@@ -7,23 +7,10 @@ import hashlib
 
 fin = ""
 fout = ""
-size = ""
 
 def main():
-
-    m = hashlib.md5()
-    m.update(fin.encode('utf8'))
-
-    ff = "/tmp/stl_to_png_%s.scad" % m.hexdigest()
-
-    f = open(ff, "w")
-    f.write("import(\"%s\");" % fin)
-    f.close()
-
-    cmd = "openscad -o %s.png --imgsize=%s,%s %s 2> /dev/null; mv %s.png %s" % (fout, size, size, ff, fout, fout)
+    cmd = "stl-thumb '%s' '%s.png' 2> /dev/null; mv '%s.png' '%s'" % (fin, fout, fout, fout)
     os.system(cmd)
-
-    os.remove(ff)
 
     sys.exit(0)
 
@@ -34,11 +21,10 @@ if __name__ == '__main__':
     f.close()
 
     if len(sys.argv) != 4:
-        print ("add args [in file] [out file] [size]")
+        print ("add args [in file] [out file]")
         sys.exit(0)
     else:
         fin = sys.argv[1]
         fout = sys.argv[2]
         size = sys.argv[3]
-
     main()


### PR DESCRIPTION
Update dependencies to use stl-thumb to generate png previews instead of openscad.